### PR TITLE
Fixed typo in Aleae manifest.

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -56,7 +56,7 @@
     {
       "slug" : "Sanguine-Aleae",
       "name" : "Aleae",
-      "description" : "Pair of polyphonic Bernoully gates based on Mutable Instruments' Branches",
+      "description" : "Pair of polyphonic Bernoulli gates based on Mutable Instruments' Branches",
       "keywords" : "Branches",
       "tags" : [
         "Random",


### PR DESCRIPTION
I noticed this typo hovering over Aleae with the module browser:

<img width="521" height="182" alt="image" src="https://github.com/user-attachments/assets/77b1b91b-c742-49b0-a851-da37d2676a67" />


This PR changes `Bernoully` to `Bernoulli` in the plugin manifest.

I searched the rest of the code and I did not see any other instances of this spelling.